### PR TITLE
set share's name just after purpose to fix #11

### DIFF
--- a/truenas/resource_truenas_share_smb.go
+++ b/truenas/resource_truenas_share_smb.go
@@ -327,6 +327,14 @@ func expandShareSMB(d *schema.ResourceData) (api.CreateShareSMBParams, error) {
 		share.Purpose = getStringPtr(purpose.(string))
 	}
 
+	if name, ok := d.GetOk("name"); ok {
+		err := isParamLocked("Name", &share)
+		if err != nil {
+			return share, err
+		}
+		share.Name = getStringPtr(name.(string))
+	}
+
 	if path_suffix, ok := d.GetOk("path_suffix"); ok {
 		err := isParamLocked("PathSuffix", &share)
 		if err != nil {
@@ -377,14 +385,6 @@ func expandShareSMB(d *schema.ResourceData) (api.CreateShareSMBParams, error) {
 			return share, err
 		}
 		share.Timemachine = getBoolPtr(timemachine.(bool))
-	}
-
-	if name, ok := d.GetOk("name"); ok {
-		err := isParamLocked("Name", &share)
-		if err != nil {
-			return share, err
-		}
-		share.Name = getStringPtr(name.(string))
 	}
 
 	ro := d.Get("ro")


### PR DESCRIPTION
To fix #11, I set the SMB share name just after the share purpose.

On a share smb resource creation with an ENHANCED_TIMEMACHINE purpose, the name is omitted and so TrueNAS will respond with an error 500. To fix this issue, I had to reorder how you set the `CreateShareSMBParams` struct.
I could not find why but the name is set to nil if we set it after `Timemachine`. If we set name before `Timemachine`, name is not omitted anymore.